### PR TITLE
 ResultItemBuilder changes

### DIFF
--- a/gsearch-core-api/src/main/java/fi/soveltia/liferay/gsearch/core/api/results/item/ResultItemBuilder.java
+++ b/gsearch-core-api/src/main/java/fi/soveltia/liferay/gsearch/core/api/results/item/ResultItemBuilder.java
@@ -17,9 +17,9 @@ import javax.portlet.PortletResponse;
 public interface ResultItemBuilder {
 
 	/**
-	 * Check if this builder can build the requested type.
+	 * Check if this builder can build the requested document.
 	 */
-	public boolean canBuild(String name);
+	public boolean canBuild(Document document);
 	
 	/**
 	 * Get item hit date.

--- a/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/query/QueryBuilderImpl.java
+++ b/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/query/QueryBuilderImpl.java
@@ -280,8 +280,7 @@ public class QueryBuilderImpl implements QueryBuilder {
 	private QueryFilterBuilder _queryFilterBuilder;
 
 	@Reference(
-		bind = "addQueryContributor", 
-		cardinality = ReferenceCardinality.MULTIPLE, 
+		cardinality = ReferenceCardinality.MULTIPLE,
 		policy = ReferencePolicy.DYNAMIC, 
 		service = QueryContributor.class, 
 		unbind = "removeQueryContributor"

--- a/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/query/filter/QueryFilterBuilderImpl.java
+++ b/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/query/filter/QueryFilterBuilderImpl.java
@@ -344,7 +344,7 @@ public class QueryFilterBuilderImpl implements QueryFilterBuilder {
 		service = PermissionFilterQueryBuilder.class, 
 		unbind = "removePermissionFilterQueryBuilder"
 	)
-	private PermissionFilterQueryBuilder _permissionFilterQueryBuilder;
+	private volatile PermissionFilterQueryBuilder _permissionFilterQueryBuilder;
 
 	private PortletRequest _portletRequest;
 

--- a/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/BlogsEntryItemBuilder.java
+++ b/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/BlogsEntryItemBuilder.java
@@ -4,6 +4,8 @@ package fi.soveltia.liferay.gsearch.core.impl.results.item;
 import com.liferay.blogs.kernel.model.BlogsEntry;
 import com.liferay.blogs.kernel.service.BlogsEntryService;
 
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -22,9 +24,9 @@ public class BlogsEntryItemBuilder extends BaseResultItemBuilder
 	implements ResultItemBuilder {
 
 	@Override
-	public boolean canBuild(String name) {
+	public boolean canBuild(Document document) {
 
-		return NAME.equals(name);
+		return NAME.equals(document.get(Field.ENTRY_CLASS_NAME));
 	}
 
 	/**

--- a/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/DLFileEntryItemBuilder.java
+++ b/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/DLFileEntryItemBuilder.java
@@ -10,6 +10,7 @@ import com.liferay.dynamic.data.mapping.service.DDMStructureLocalServiceUtil;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
 import com.liferay.portal.kernel.dao.orm.RestrictionsFactoryUtil;
 import com.liferay.portal.kernel.repository.model.FileEntry;
+import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.PortalUtil;
@@ -38,9 +39,9 @@ public class DLFileEntryItemBuilder extends BaseResultItemBuilder
 	implements ResultItemBuilder {
 
 	@Override
-	public boolean canBuild(String name) {
+	public boolean canBuild(Document document) {
 
-		return NAME.equals(name);
+		return NAME.equals(document.get(Field.ENTRY_CLASS_NAME));
 	}
 
 	/**

--- a/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/JournalArticleItemBuilder.java
+++ b/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/JournalArticleItemBuilder.java
@@ -6,6 +6,8 @@ import com.liferay.journal.service.JournalArticleService;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.Validator;
 
@@ -28,9 +30,9 @@ public class JournalArticleItemBuilder extends BaseResultItemBuilder
 	implements ResultItemBuilder {
 
 	@Override
-	public boolean canBuild(String name) {
+	public boolean canBuild(Document document) {
 
-		return NAME.equals(name);
+		return NAME.equals(document.get(Field.ENTRY_CLASS_NAME));
 	}
 
 	/**

--- a/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/KBArticleItemBuilder.java
+++ b/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/KBArticleItemBuilder.java
@@ -4,6 +4,8 @@ package fi.soveltia.liferay.gsearch.core.impl.results.item;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
 
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
 import org.osgi.service.component.annotations.Component;
 
 import fi.soveltia.liferay.gsearch.core.api.results.item.ResultItemBuilder;
@@ -21,9 +23,9 @@ public class KBArticleItemBuilder extends BaseResultItemBuilder
 	implements ResultItemBuilder {
 
 	@Override
-	public boolean canBuild(String name) {
+	public boolean canBuild(Document document) {
 
-		return NAME.equals(name);
+		return NAME.equals(document.get(Field.ENTRY_CLASS_NAME));
 	}
 
 	/**

--- a/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/MBMessageItemBuilder.java
+++ b/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/MBMessageItemBuilder.java
@@ -8,6 +8,7 @@ import com.liferay.message.boards.kernel.model.MBMessage;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.portlet.LiferayPortletRequest;
 import com.liferay.portal.kernel.portlet.LiferayPortletResponse;
+import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.HtmlUtil;
@@ -36,10 +37,9 @@ public class MBMessageItemBuilder extends BaseResultItemBuilder
 	implements ResultItemBuilder {
 
 	@Override
-	public boolean canBuild(String name) {
+	public boolean canBuild(Document document) {
 
-		return NAME.equals(name);
-	}
+		return NAME.equals(document.get(Field.ENTRY_CLASS_NAME));	}
 
 	/**
 	 * This currently handles links for following MBMessage types (by message

--- a/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/NonLiferaySampleItemBuilder.java
+++ b/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/NonLiferaySampleItemBuilder.java
@@ -1,6 +1,8 @@
 
 package fi.soveltia.liferay.gsearch.core.impl.results.item;
 
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.portal.kernel.search.SearchException;
 
 import org.osgi.service.component.annotations.Component;
@@ -20,9 +22,9 @@ public class NonLiferaySampleItemBuilder extends BaseResultItemBuilder
 	implements ResultItemBuilder {
 
 	@Override
-	public boolean canBuild(String name) {
+	public boolean canBuild(Document document) {
 
-		return NAME.equals(name);
+		return NAME.equals(document.get(Field.ENTRY_CLASS_NAME));
 	}
 
 	/**

--- a/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/ResultItemBuilderFactoryImpl.java
+++ b/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/ResultItemBuilderFactoryImpl.java
@@ -43,7 +43,7 @@ public class ResultItemBuilderFactoryImpl implements ResultItemBuilderFactory {
 		ResultItemBuilder resultItemBuilder = null;
 
 		for (ResultItemBuilder r : _resultItemBuilders) {
-			if (r.canBuild(entryClassName)) {
+			if (r.canBuild(document)) {
 				resultItemBuilder = r;
 				break;
 			}

--- a/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/ResultItemBuilderFactoryImpl.java
+++ b/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/ResultItemBuilderFactoryImpl.java
@@ -6,12 +6,13 @@ import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.search.Document;
 import com.liferay.portal.kernel.search.Field;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletResponse;
 
+import com.liferay.portal.kernel.util.SortedArrayList;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 import org.osgi.service.component.annotations.ReferenceCardinality;
@@ -42,9 +43,9 @@ public class ResultItemBuilderFactoryImpl implements ResultItemBuilderFactory {
 
 		ResultItemBuilder resultItemBuilder = null;
 
-		for (ResultItemBuilder r : _resultItemBuilders) {
-			if (r.canBuild(document)) {
-				resultItemBuilder = r;
+		for (ResultItemBuilderReference r : _resultItemBuilderReferences) {
+			if (r.getResultItemBuilder().canBuild(document)) {
+				resultItemBuilder = r.getResultItemBuilder();
 				break;
 			}
 		}
@@ -60,38 +61,44 @@ public class ResultItemBuilderFactoryImpl implements ResultItemBuilderFactory {
 		return resultItemBuilder;
 	}
 
-	/**
-	 * Add result item builder to the list.
-	 * 
-	 * @param clauseBuilder
-	 */
-	protected void addResultItemBuilder(ResultItemBuilder resultItemBuilder) {
+	@Reference(
+			cardinality = ReferenceCardinality.MULTIPLE,
+			policy = ReferencePolicy.DYNAMIC,
+			service = ResultItemBuilder.class,
+			unbind = "removeResultItemBuilder"
+	)
+	protected synchronized void addResultItemBuilder(
+			ResultItemBuilder resultItemBuilder,
+			Map<String, Object> properties) {
 
-		if (_resultItemBuilders == null) {
-			_resultItemBuilders = new ArrayList<ResultItemBuilder>();
+		Integer serviceRanking = (Integer)properties.get("service.ranking");
+
+		if (serviceRanking == null) {
+			serviceRanking = 0;
 		}
-		_resultItemBuilders.add(resultItemBuilder);
+
+		_resultItemBuilderReferences.add(
+				new ResultItemBuilderReference(resultItemBuilder, serviceRanking));
 	}
 
 	/**
 	 * Remove a clause builder from list.
-	 * 
-	 * @param clauseBuilder
+	 *
+	 * @param resultItemBuilder
 	 */
-	protected void removeResultItemBuilder(
+	protected synchronized void removeResultItemBuilder(
 		ResultItemBuilder resultItemBuilder) {
 
-		_resultItemBuilders.remove(resultItemBuilder);
+		for (ResultItemBuilderReference reference : _resultItemBuilderReferences) {
+			if (reference.getResultItemBuilder() == resultItemBuilder) {
+				_resultItemBuilderReferences.remove(reference);
+				break;
+			}
+		}
 	}
 
-	@Reference(
-		bind = "addResultItemBuilder", 
-		cardinality = ReferenceCardinality.MULTIPLE, 
-		policy = ReferencePolicy.DYNAMIC, 
-		service = ResultItemBuilder.class,
-		unbind = "removeResultItemBuilder"
-	)
-	private volatile List<ResultItemBuilder> _resultItemBuilders;
+	private volatile List<ResultItemBuilderReference> _resultItemBuilderReferences =
+			new SortedArrayList<>();
 
 	private static final Log _log =
 		LogFactoryUtil.getLog(ResultItemBuilderFactoryImpl.class);

--- a/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/ResultItemBuilderReference.java
+++ b/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/ResultItemBuilderReference.java
@@ -1,0 +1,31 @@
+package fi.soveltia.liferay.gsearch.core.impl.results.item;
+
+import fi.soveltia.liferay.gsearch.core.api.results.item.ResultItemBuilder;
+
+/**
+ * Class for keeping ResultItemBuilder and service ranking together and making
+ * ResultItemBuilder comparable by ranking.
+ */
+public class ResultItemBuilderReference implements Comparable<ResultItemBuilderReference> {
+
+    public ResultItemBuilderReference(ResultItemBuilder resultItemBuilder, int serviceRanking) {
+
+        _resultItemBuilder = resultItemBuilder;
+        _serviceRanking = serviceRanking;
+    }
+
+    public ResultItemBuilder getResultItemBuilder() {
+
+        return _resultItemBuilder;
+    }
+
+    @Override
+    public int compareTo(ResultItemBuilderReference r) {
+
+        // Return descending order
+        return Integer.compare(r._serviceRanking, this._serviceRanking);
+    }
+
+    private ResultItemBuilder _resultItemBuilder;
+    private int _serviceRanking;
+}

--- a/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/WikiPageItemBuilder.java
+++ b/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/results/item/WikiPageItemBuilder.java
@@ -1,6 +1,8 @@
 
 package fi.soveltia.liferay.gsearch.core.impl.results.item;
 
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.Field;
 import com.liferay.wiki.model.WikiPage;
 
 import org.osgi.service.component.annotations.Component;
@@ -20,9 +22,9 @@ public class WikiPageItemBuilder extends BaseResultItemBuilder
 	implements ResultItemBuilder {
 
 	@Override
-	public boolean canBuild(String name) {
+	public boolean canBuild(Document document) {
 
-		return NAME.equals(name);
+		return NAME.equals(document.get(Field.ENTRY_CLASS_NAME));
 	}
 
 	private static final String NAME = WikiPage.class.getName();


### PR DESCRIPTION
ResultItemBuilder.canBuild() is more versatile when it will take document as a parameter instead of the entryclassName. 

ResultItemBuilder:s can now be ordered by ranking, for example
property = {"service.ranking:Integer=100"}