### PR TITLE
Match query builder issue

### DIFF
--- a/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/query/clause/MatchQueryBuilderImpl.java
+++ b/gsearch-core-impl/src/main/java/fi/soveltia/liferay/gsearch/core/impl/query/clause/MatchQueryBuilderImpl.java
@@ -120,7 +120,7 @@ public class MatchQueryBuilderImpl implements ClauseBuilder {
 			GetterUtil.getString(configurationObject.get("operator"), "and");
 
 		if ("or".equals(operator)) {
-			matchQuery.setOperator(Operator.AND);
+			matchQuery.setOperator(Operator.OR);
 		}
 		else {
 			matchQuery.setOperator(Operator.AND);


### PR DESCRIPTION
This conditional structure has the same code blocks. The first one should set the Operator.OR operator